### PR TITLE
Add after_wpsc_delete_cache_directory hook

### DIFF
--- a/projects/plugins/super-cache/inc/delete-cache-button.php
+++ b/projects/plugins/super-cache/inc/delete-cache-button.php
@@ -108,6 +108,10 @@ function wpsc_admin_bar_delete_cache() {
 	$req_path = isset( $_POST['path'] ) ? sanitize_text_field( stripslashes( $_POST['path'] ) ) : '';
 	$valid_nonce = ( $req_path && isset( $_POST['nonce'] ) ) ? wp_verify_nonce( $_POST['nonce'], 'delete-cache-' . $_POST['path'] . '_' . $_POST['admin'] ) : false;
 
+	if ($valid_nonce) {
+		do_action('after_wpsc_delete_cache_directory', $req_path, $referer);
+	}
+
 	if ( $valid_nonce && $referer && $req_path && ( false !== stripos( $referer, $req_path ) || 0 === stripos( $referer, wp_login_url() ) ) ) {
 		if ( $_POST['admin'] ) {
 			wp_safe_redirect( $referer );


### PR DESCRIPTION
Added after_wpsc_delete_cache_directory hook, which is executed every time someone hits button to clear cache. This is inteded to integrate SuperCache with other Caching providers, eg. Cloudflare.

Main goal to add this, was to enable purge entire CF Cache (or only one page) even, when no WP Super Cache is present (in that case, wp_cache_cleared hook isn't executed).

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added `after_wpsc_delete_cache_directory` hook

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add action to `after_wpsc_delete_cache_directory` hook
